### PR TITLE
Refactoring/continue scripts trimming

### DIFF
--- a/src/Pantry.js
+++ b/src/Pantry.js
@@ -8,6 +8,10 @@ class Pantry {
   addIngredientToPantry(ingredient) {
     this.data.push(ingredient);
   }
+
+  getIngredientName(id) {
+    return this.data.find(ingredient => id === ingredient.id).name;
+  }
 }
 
 module.exports = Pantry;

--- a/src/RecipeRepository.js
+++ b/src/RecipeRepository.js
@@ -19,6 +19,10 @@ class RecipeRepository {
     this.tagNames.sort();
   }
 
+  getRecipeByID(id) {
+    return this.data.find(recipe => id === recipe.id);
+  }
+  
   getRecipesByTag(tags) {
     return this.data.reduce((recipes, curRecipe) => {
       tags.forEach(tag => {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -35,6 +35,15 @@ let domUpdates = {
     });
   },
 
+  displayRecipeInfo(recipe, ingredients, recipeInfo) {
+    recipeInfo.style.display = "inline";
+
+    this.generateRecipeTitle(recipe, ingredients, recipeInfo);
+    this.addRecipeImage(recipe);
+    this.generateInstructions(recipe, recipeInfo);
+    this.renderAdjacentHTML(recipeInfo, "<section id='overlay'></div>");
+  },
+
   generateRecipeTitle(recipe, ingredients, fullRecipeInfo) {
     let recipeTitle = `
       <button id="exit-recipe-btn">X</button>

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -95,6 +95,11 @@ let domUpdates = {
     document.getElementById("overlay").remove();
   },
 
+  showWelcomeBanner() {
+    this.renderDisplayStyling(".welcome-msg", "flex");
+    this.renderDisplayStyling(".my-recipes-banner", "none");
+  },
+  
   renderDisplayStyling(className, styleDisplayProperty) {
     document.querySelector(className).style.display = styleDisplayProperty;
   },

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -90,8 +90,9 @@ let domUpdates = {
     fullRecipeInfo.insertAdjacentHTML("beforeend", `<ol>${instructionsList}</ol>`);
   },
 
-  removeStyling(idName) {
-    document.getElementById(idName).remove();
+  hideInfo(recipeInfo) {
+    recipeInfo.style.display = "none";
+    document.getElementById("overlay").remove();
   },
 
   renderDisplayStyling(className, styleDisplayProperty) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -124,7 +124,7 @@ function performActionOnMain(event) {
   } else if (isDescendant(recipeCard, event.target)) {
     openRecipeInfo(recipeCard);
   } else if (event.target.id === "exit-recipe-btn") {
-    exitRecipe();
+    exitRecipeInfo();
   }
 }
 
@@ -159,7 +159,6 @@ function showSavedRecipes() {
   const unsavedRecipes = recipes.data.filter(recipe => {
     return !user.favoriteRecipes.includes(recipe.id);
   });
-
   domUpdates.displaySaved(unsavedRecipes);
 }
 
@@ -170,7 +169,6 @@ function openRecipeInfo(recipeCard) {
       return recipe.id === Number(recipeCard.id);
     });
     const ingredients = generateIngredients(recipe);
-    
     domUpdates.displayRecipeInfo(recipe, ingredients, recipeInfo);
 }
 
@@ -181,11 +179,9 @@ function generateIngredients(recipe) {
   }).join(", ");
 }
 
-function exitRecipe() {
-  while (recipeInfo.firstChild &&
-    recipeInfo.removeChild(recipeInfo.firstChild));
-  recipeInfo.style.display = "none";
-  domUpdates.removeStyling("overlay");
+function exitRecipeInfo() {
+  recipeInfo.replaceChildren();
+  domUpdates.hideInfo(recipeInfo);
 }
 
 // TOGGLE DISPLAYS

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -12,7 +12,7 @@ import { getAllData, capitalize } from "./utils.js";
 
 let allRecipesBtn = document.querySelector(".show-all-btn");
 let filterBtn = document.querySelector("#filter-btn");
-let fullRecipeInfo = document.querySelector("#recipe-instructions");
+let recipeInfo = document.querySelector("#recipe-instructions");
 let main = document.querySelector("main");
 let pantry = new Pantry();
 let pantryBtn = document.querySelector("#my-pantry-btn");
@@ -105,7 +105,7 @@ function findCheckedBoxes() {
 }
 
 function filterRecipes(filteredRecipes) {
-  let unselectedRecipes = recipes.data.filter(recipe => {
+  const unselectedRecipes = recipes.data.filter(recipe => {
     return !filteredRecipes.includes(recipe);
   });
 
@@ -117,12 +117,14 @@ function filterRecipes(filteredRecipes) {
 // MAIN SECTION HANDLER
 
 function performActionOnMain(event) {
+  const recipeCard = event.target.closest(".recipe-card");
+
   if (event.target.className === "card-apple-icon") {
     toggleSaved(event);
+  } else if (isDescendant(recipeCard, event.target)) {
+    openRecipeInfo(recipeCard);
   } else if (event.target.id === "exit-recipe-btn") {
     exitRecipe();
-  } else if (isDescendant(event.target.closest(".recipe-card"), event.target)) {
-    openRecipeInfo(event);
   }
 }
 
@@ -157,21 +159,19 @@ function showSavedRecipes() {
   const unsavedRecipes = recipes.data.filter(recipe => {
     return !user.favoriteRecipes.includes(recipe.id);
   });
-
+  
   domUpdates.displaySaved(unsavedRecipes);
 }
 
 // CREATE RECIPE INSTRUCTIONS
 
-function openRecipeInfo(event) {
-    let recipeId = event.path.find(e => e.id).id;
-    let recipe = recipes.data.find(recipe => recipe.id === Number(recipeId));
+function openRecipeInfo(recipeCard) {
+    const recipe = recipes.data.find(recipe => {
+      return recipe.id === Number(recipeCard.id);
+    });
+    const ingredients = generateIngredients(recipe);
 
-    fullRecipeInfo.style.display = "inline";
-    domUpdates.generateRecipeTitle(recipe, generateIngredients(recipe), fullRecipeInfo);
-    domUpdates.addRecipeImage(recipe);
-    domUpdates.generateInstructions(recipe, fullRecipeInfo);
-    domUpdates.renderAdjacentHTML(fullRecipeInfo, "<section id='overlay'></div>");
+    domUpdates.displayRecipeInfo(recipe, ingredients, recipeInfo);
 }
 
 function generateIngredients(recipe) {
@@ -185,9 +185,9 @@ function generateIngredients(recipe) {
 }
 
 function exitRecipe() {
-  while (fullRecipeInfo.firstChild &&
-    fullRecipeInfo.removeChild(fullRecipeInfo.firstChild));
-  fullRecipeInfo.style.display = "none";
+  while (recipeInfo.firstChild &&
+    recipeInfo.removeChild(recipeInfo.firstChild));
+  recipeInfo.style.display = "none";
   domUpdates.removeStyling("overlay");
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -159,27 +159,24 @@ function showSavedRecipes() {
   const unsavedRecipes = recipes.data.filter(recipe => {
     return !user.favoriteRecipes.includes(recipe.id);
   });
-  
+
   domUpdates.displaySaved(unsavedRecipes);
 }
 
-// CREATE RECIPE INSTRUCTIONS
+// DISPLAY RECIPE INSTRUCTIONS
 
 function openRecipeInfo(recipeCard) {
     const recipe = recipes.data.find(recipe => {
       return recipe.id === Number(recipeCard.id);
     });
     const ingredients = generateIngredients(recipe);
-
+    
     domUpdates.displayRecipeInfo(recipe, ingredients, recipeInfo);
 }
 
 function generateIngredients(recipe) {
-  return recipe && recipe.ingredients.map(i => {
-    const ingredient = pantry.data.find(ingredient => {
-      return i.id === ingredient.id;
-    }).name;
-
+  return recipe.ingredients.map(i => {
+    const ingredient = pantry.getIngredientName(i.id);
     return `${capitalize(ingredient)} (${i.quantity.amount} ${i.quantity.unit})`
   }).join(", ");
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -165,10 +165,9 @@ function showSavedRecipes() {
 // DISPLAY RECIPE INSTRUCTIONS
 
 function openRecipeInfo(recipeCard) {
-    const recipe = recipes.data.find(recipe => {
-      return recipe.id === Number(recipeCard.id);
-    });
+    const recipe = recipes.getRecipeByID(Number(recipeCard.id));
     const ingredients = generateIngredients(recipe);
+    
     domUpdates.displayRecipeInfo(recipe, ingredients, recipeInfo);
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -184,12 +184,6 @@ function exitRecipeInfo() {
   domUpdates.hideInfo(recipeInfo);
 }
 
-// TOGGLE DISPLAYS
-function showWelcomeBanner() {
-  domUpdates.renderDisplayStyling(".welcome-msg", "flex");
-  domUpdates.renderDisplayStyling(".my-recipes-banner", "none");
-}
-
 // SEARCH RECIPES
 function pressEnterSearch(event) {
   event.preventDefault();
@@ -217,7 +211,7 @@ function showAllRecipes() {
     let domRecipe = document.getElementById(`${recipe.id}`);
     domRecipe.style.display = "block";
   });
-  showWelcomeBanner();
+  domUpdates.showWelcomeBanner();
 }
 
 // CREATE AND USE PANTRY


### PR DESCRIPTION
## Is this a fix or a feature?
- Neither (refactoring)

## What is the change?
This PR entails the refactoring of all functionality within the "Display Recipe Instructions" section of 'scripts.js'. The following was also done:
- Encapsulated 'openRecipeInfo()' DOM manipulation functions into a single handler, 'displayRecipeInfo()' within 'domUpdates.js'
- Moved functionality, in 'openRecipeInfo()', that gets Recipe by ID to RecipeRepository
- Trimmed 'exitRecipeInfo()' functionality for removing info children
- Added handler for toggling the welcome banner to 'domUpdates.js'

## Where should the reviewer start?
- With the "Display Recipe Instructions" section of 'scripts.js'

## How should this be tested?
- Open app in browser and very that functionality still remains and verify no new errors appear in console
