### PR TITLE
Refactor searchRecipes() functionality

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -205,10 +205,29 @@ function pressEnterSearch(event) {
 
 function searchRecipes() {
   showAllRecipes();
-  let searchedRecipes = recipes.data.filter(recipe => {
+
+  let searchedNames = searchRecipeNames();
+  let searchedIngredients = searchRecipeIngredients();
+  let searchedRecipes = searchedNames.concat(searchedIngredients);
+  
+  filterNonSearched(searchedRecipes);
+}
+
+function searchRecipeNames() {
+  return recipes.data.filter(recipe => {
     return recipe.name.toLowerCase().includes(searchInput.value.toLowerCase());
   });
-  filterNonSearched(searchedRecipes);
+}
+
+function searchRecipeIngredients() {
+  return recipes.data.reduce((matches, recipe) => {
+    recipe.ingredients.forEach(ingredient => {
+      if (ingredient.name.toLowerCase().includes(searchInput.value.toLowerCase())) {
+        matches.push(recipe);
+      }
+    });
+    return matches;
+  },[]);
 }
 
 function filterNonSearched(filtered) {


### PR DESCRIPTION
## Is this a fix or a feature?
Both.

## What is the change?
Refactored the **searchRecipes()** function.  Now split into 3 functions:
1. _searchRecipes()_: still the primary function, but acts now as a helper that calls two other filtering functions, then concatenates the returned arrays of results from each, to calls the _filterNonSearched()_ function with the combined array passed in as an argument.
2. _searchRecipeNames()_: searches recipes for matches in the recipe name, returns array of filtered results.
3. _searchRecipeIngredients()_: searches each ingredient name in each recipe for a match, returns array of filtered results.

## What does it fix?
We can now search for recipes by ingredient!

## Where should the reviewer start?
Just check that our search function works as intended, then we can continue refactoring with the _filterNonSearched()_ and _showAllRecipes()_ functions.

## How should this be tested?
Dev tools.